### PR TITLE
Update HelloWorld.md

### DIFF
--- a/molgenis-compute-core/HelloWorld.md
+++ b/molgenis-compute-core/HelloWorld.md
@@ -32,7 +32,8 @@ The following commands show the help.
 	cat parameters.csv
 
 ### Inspect the MOLGENIS Compute parameter defaults
-	cat compute.properties
+	cd ~/molgenis-compute-core-0.0.1-SNAPSHOT
+	cat .compute.properties
 
 ## Generate a workflow with scripts for your parameters
 The following commands are equivalent. Parameters that are not specified are retrieved from the compute.properties file.


### PR DESCRIPTION
Before printing the default MOLGENIS Compute parameter defaults (from the [.]compute.properties file?) and running the molgenis_compute.sh script, we need to go back to the initial directory (something like ~/[...]/molgenis-compute-core-0.0.1-SNAPSHOT).
