### PR TITLE
remove hardcoded patch, spellingfix 

### DIFF
--- a/molgenis-compute-core/src/main/resources/templates/slurm/submit.ftl
+++ b/molgenis-compute-core/src/main/resources/templates/slurm/submit.ftl
@@ -20,7 +20,7 @@ touch molgenis.submit.started
 skip(){
 echo "0: Skipped --- TASK '$1' --- ON $(date +"%Y-%m-%d %T")" >> molgenis.skipped.log
 }
-=
+
 <#foreach t in tasks>
 #
 ##${t.name}

--- a/molgenis-compute-core/src/main/resources/templates/slurm/submit.ftl
+++ b/molgenis-compute-core/src/main/resources/templates/slurm/submit.ftl
@@ -20,8 +20,7 @@ touch molgenis.submit.started
 skip(){
 echo "0: Skipped --- TASK '$1' --- ON $(date +"%Y-%m-%d %T")" >> molgenis.skipped.log
 }
-<#noparse>echo -e "../../../../tmp/submits/${projectName}_${run}.txt" > zubmitted_jobIDs.txt</#noparse>
-
+=
 <#foreach t in tasks>
 #
 ##${t.name}
@@ -47,13 +46,11 @@ fi
 output=$(sbatch $dependencies ${t.name}.sh)
 id=${t.name}
 ${t.name}=<#noparse>${output##"Submitted batch job "}</#noparse>
-echo "$id:$${t.name}"<#noparse> | tee -a ../../../../tmp/submits/${projectName}_${run}.txt</#noparse>
-echo "$id:$${t.name}" >> zubmitted_jobIDs.txt
+echo "$id:$${t.name}"<#noparse> =
+echo "$id:$${t.name}" >> submitted_jobIDs.txt
 fi
 
 </#foreach>
-<#noparse> echo "jobIDs are in ../../../../tmp/submits/${projectName}_${run}.txt"
-chmod g+w ../../../../tmp/submits/${projectName}_${run}.txt
-chmod g+w zubmitted_jobIDs.txt
+chmod g+w submitted_jobIDs.txt
 </#noparse>
 touch molgenis.submit.finished

--- a/molgenis-compute-core/src/main/resources/templates/slurm/submit.ftl
+++ b/molgenis-compute-core/src/main/resources/templates/slurm/submit.ftl
@@ -46,7 +46,7 @@ fi
 output=$(sbatch $dependencies ${t.name}.sh)
 id=${t.name}
 ${t.name}=<#noparse>${output##"Submitted batch job "}</#noparse>
-echo "$id:$${t.name}"<#noparse> =
+echo "$id:$${t.name}"<#noparse> 
 echo "$id:$${t.name}" >> submitted_jobIDs.txt
 fi
 


### PR DESCRIPTION
Hardcoded path causes errors if job folder structure is different